### PR TITLE
shows up heroku env variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM heroku/cedar:14
+
+WORKDIR /usr/local/lib
+
+RUN curl --silent https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/shunit2/shunit2-2.1.6.tgz | tar xz
+
+ENV SHUNIT_HOME /usr/local/lib/shunit2-2.1.6
+
+ADD bin /app/testrunner/bin
+ADD lib /app/testrunner/lib
+
+CMD ["-c", "/app/buildpack"]
+ENTRYPOINT ["/app/testrunner/bin/run"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # heroku-buildpack-gatsby
+
+### Testing with Docker
+
+`./build.sh`
+
+`docker run -it -v /path/to/heroku-buildpack-gatsby:/app/buildpack:ro heroku/buildpack-testrunner`
+
+[Documentation](https://github.com/heroku/heroku-buildpack-testrunner#docker-usage)

--- a/bin/compile
+++ b/bin/compile
@@ -6,6 +6,11 @@ BUILD_DIR=$1/marketing
 # the file name is the variable name, and the file contents are the variable’s value.
 ENV_DIR=$3
 
+# Heroku has opinions on indentation, let's respect them
+indent() {
+  sed -u 's/^/       /'
+}
+
 # Export env vars from ENV_DIR to environment
 # https://devcenter.heroku.com/articles/buildpack-api
 export_env_dir() {
@@ -20,6 +25,7 @@ export_env_dir() {
     done
   fi
 }
+
 export_env_dir "$ENV_DIR"
 
 cd $BUILD_DIR
@@ -28,3 +34,4 @@ yarn
 yarn run gatsby build
 mv public/* ../public/
 
+echo "Done" | indent

--- a/bin/compile
+++ b/bin/compile
@@ -2,6 +2,26 @@
 
 BUILD_DIR=$1/marketing
 
+# file directory that contains all of the environment variables provided from the Heroku setup.
+# the file name is the variable name, and the file contents are the variable’s value.
+ENV_DIR=$3
+
+# Export env vars from ENV_DIR to environment
+# https://devcenter.heroku.com/articles/buildpack-api
+export_env_dir() {
+  env_dir=$1
+  whitelist_regex=${2:-''}
+  blacklist_regex=${3:-'^(PATH|GIT_DIR|CPATH|CPPATH|LD_PRELOAD|LIBRARY_PATH)$'}
+  if [ -d "$env_dir" ]; then
+    for e in $(ls $env_dir); do
+      echo "$e" | grep -E "$whitelist_regex" | grep -qvE "$blacklist_regex" &&
+      export "$e=$(cat $env_dir/$e)"
+      :
+    done
+  fi
+}
+export_env_dir "$ENV_DIR"
+
 cd $BUILD_DIR
 
 yarn

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+docker build -t heroku/testrunner .

--- a/test/compile_test.sh
+++ b/test/compile_test.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+. ${BUILDPACK_TEST_RUNNER_HOME}/lib/test_utils.sh
+
+testCompile()
+{
+  # set arbitrary env vars
+  echo "foo" > $ENV_DIR/FOO
+
+  capture ${BUILDPACK_HOME}/bin/compile ${BUILD_DIR} ${CACHE_DIR} ${ENV_DIR}
+  assertCaptured "Done"
+}


### PR DESCRIPTION
Ref: https://devcenter.heroku.com/articles/buildpack-api#bin-compile
Related: https://github.com/dovetail-studios/marmalade/pull/482/commits

Problem: I would like to use the `GOOGLE_RECAPTCHA_SECRET_KEY ` env variable defined in Heroku, but the current buildpack doesn't include these variables.

Solution: Follow heroku doc, load the env vars before run the build.
